### PR TITLE
feat(progress-logger): added a progress logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,7 @@ dependencies = [
  "mimalloc",
  "num_cpus",
  "parking_lot",
+ "proglog",
  "rayon",
  "regex",
  "seq_io",
@@ -564,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
@@ -718,6 +719,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "proglog"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0907d41e1427d25a0b6376a803c9cb15d2e46586cca3a9560391c56661186aa3"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ log = "0.4.14"
 mimalloc = {version = "0.1.26", default-features = false}
 num_cpus = "1.13.0"
 parking_lot = "0.11.2"
+proglog = "0.2.0"
 rayon = "1.5.1"
 regex = "1.5.4"
 seq_io = "0.3.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use itertools::{self, izip, Itertools};
 use lazy_static::lazy_static;
 use log::info;
 use parking_lot::Mutex;
+use proglog::ProgLogBuilder;
 use rayon::prelude::*;
 use regex::{Regex, RegexBuilder};
 use seq_io::fastq::{self, OwnedRecord};
@@ -333,6 +334,13 @@ struct Barcode<'a>(&'a [u8], &'a [u8]);
 #[allow(clippy::too_many_lines)]
 fn main() -> Result<()> {
     let opts = setup();
+    let progress_logger = ProgLogBuilder::new()
+        .name("fqgrep-progress")
+        .noun("reads")
+        .verb("Searched")
+        .unit(50_000_000)
+        .build();
+
     let ref_sample = Sample::from_r1_path(&opts.r1_fastq, REF_PREFIX)?;
     let alt_sample = Sample::from_r1_path(&opts.r1_fastq, ALT_PREFIX)?;
     let both_sample = Sample::from_r1_path(&opts.r1_fastq, BOTH_PREFIX)?;
@@ -379,6 +387,7 @@ fn main() -> Result<()> {
                         (false, true) => Matches::Alt,
                         (false, false) => Matches::None,
                     };
+                    progress_logger.record();
                     (m, (r1, r2))
                 })
                 .filter(|(m, _)| *m != Matches::None)
@@ -406,7 +415,7 @@ fn main() -> Result<()> {
                 )
                 .for_each(
                     |(ref_reads, alt_reads, both_reads): MatchedReads| {
-                        // Aquire lock to ensure R1 and R2 are enqueued at the same time
+                        // Acquire lock to ensure R1 and R2 are enqueued at the same time
                         {
                             let _lock = ref_writer.lock.lock();
                             ref_writer.r1.tx.as_ref().unwrap().send(ref_reads.0).expect("Failed to send R1s");
@@ -475,7 +484,7 @@ fn main() -> Result<()> {
         .handle
         .join()
         .expect("Error joining r2 handle");
-
+    drop(progress_logger);
     info!(
         "{} reads matched input ref sequence",
         ref_r1_stats.reads_written


### PR DESCRIPTION
This PR adds a simple progress logger into the hot loop to "greps" the reads to track how many reads have been searched so far. With it's existing configuration it emits ~ 1 log message every 30 seconds.

Example logging output of a full run:

```text
[2022-08-05T18:03:56Z INFO  fqgrep] Creating reader threads
[2022-08-05T18:03:56Z INFO  fqgrep] Processing reads
[2022-08-05T18:04:27Z INFO  proglog] [fqgrep-progress] Searched 50000000 reads
[2022-08-05T18:04:57Z INFO  proglog] [fqgrep-progress] Searched 100000000 reads
[2022-08-05T18:05:28Z INFO  proglog] [fqgrep-progress] Searched 150000000 reads
[2022-08-05T18:05:58Z INFO  proglog] [fqgrep-progress] Searched 200000000 reads
[2022-08-05T18:06:28Z INFO  proglog] [fqgrep-progress] Searched 250000000 reads
[2022-08-05T18:06:58Z INFO  proglog] [fqgrep-progress] Searched 300000000 reads
[2022-08-05T18:07:29Z INFO  proglog] [fqgrep-progress] Searched 350000000 reads
[2022-08-05T18:07:59Z INFO  proglog] [fqgrep-progress] Searched 400000000 reads
[2022-08-05T18:08:29Z INFO  proglog] [fqgrep-progress] Searched 450000000 reads
[2022-08-05T18:08:59Z INFO  proglog] [fqgrep-progress] Searched 500000000 reads
[2022-08-05T18:09:30Z INFO  proglog] [fqgrep-progress] Searched 550000000 reads
[2022-08-05T18:10:00Z INFO  proglog] [fqgrep-progress] Searched 600000000 reads
[2022-08-05T18:10:30Z INFO  proglog] [fqgrep-progress] Searched 650000000 reads
[2022-08-05T18:11:01Z INFO  proglog] [fqgrep-progress] Searched 700000000 reads
[2022-08-05T18:11:31Z INFO  proglog] [fqgrep-progress] Searched 750000000 reads
[2022-08-05T18:12:01Z INFO  proglog] [fqgrep-progress] Searched 800000000 reads
[2022-08-05T18:12:30Z INFO  proglog] [fqgrep-progress] Searched 850000000 reads
[2022-08-05T18:13:01Z INFO  proglog] [fqgrep-progress] Searched 900000000 reads
[2022-08-05T18:13:31Z INFO  proglog] [fqgrep-progress] Searched 950000000 reads
[2022-08-05T18:14:01Z INFO  proglog] [fqgrep-progress] Searched 1000000000 reads
[2022-08-05T18:14:32Z INFO  proglog] [fqgrep-progress] Searched 1050000000 reads
[2022-08-05T18:15:02Z INFO  proglog] [fqgrep-progress] Searched 1100000000 reads
[2022-08-05T18:15:32Z INFO  proglog] [fqgrep-progress] Searched 1150000000 reads
[2022-08-05T18:16:02Z INFO  proglog] [fqgrep-progress] Searched 1200000000 reads
[2022-08-05T18:16:33Z INFO  proglog] [fqgrep-progress] Searched 1250000000 reads
[2022-08-05T18:17:03Z INFO  proglog] [fqgrep-progress] Searched 1300000000 reads
[2022-08-05T18:17:33Z INFO  proglog] [fqgrep-progress] Searched 1350000000 reads
[2022-08-05T18:17:54Z INFO  fqgrep] Joining reader threads
[2022-08-05T18:17:54Z INFO  fqgrep] Joining writer threads and collecting stats
[2022-08-05T18:17:54Z INFO  proglog] [fqgrep-progress] Searched 1384167117 reads
[2022-08-05T18:17:54Z INFO  fqgrep] 52820 reads matched input ref sequence
[2022-08-05T18:17:54Z INFO  fqgrep] 98740 reads matched input alt sequence
[2022-08-05T18:17:54Z INFO  fqgrep] 7 reads matched both input ref and alt sequences
[2022-08-05T18:17:54Z INFO  fqgrep] Writing stats
```

With some crude CLI benchmarking on both `fqgrep` and other projects `proglog` does not slow down hot loops to any appreciable degree as long as `unit` size is set high enough.