### PR TITLE
feat(pretty_progress_logger): uses commas to delimit large numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,11 +728,12 @@ dependencies = [
 
 [[package]]
 name = "proglog"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0907d41e1427d25a0b6376a803c9cb15d2e46586cca3a9560391c56661186aa3"
+checksum = "67860745d19bbec62e2c750b3134443fd2c1990213809e5d47914cc5ccafcd25"
 dependencies = [
  "log",
+ "thousands",
 ]
 
 [[package]]
@@ -960,6 +961,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "tinyvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ log = "0.4.14"
 mimalloc = {version = "0.1.26", default-features = false}
 num_cpus = "1.13.0"
 parking_lot = "0.11.2"
-proglog = "0.2.0"
+proglog = {version = "0.3.0", features = ["pretty_counts"]}
 rayon = "1.5.1"
 regex = "1.5.4"
 seq_io = "0.3.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use itertools::{self, izip, Itertools};
 use lazy_static::lazy_static;
 use log::info;
 use parking_lot::Mutex;
-use proglog::ProgLogBuilder;
+use proglog::{CountFormatterKind, ProgLogBuilder};
 use rayon::prelude::*;
 use regex::{Regex, RegexBuilder};
 use seq_io::fastq::{self, OwnedRecord};
@@ -361,6 +361,7 @@ fn main() -> Result<()> {
         .noun("reads")
         .verb("Searched")
         .unit(50_000_000)
+        .count_formatter(CountFormatterKind::Comma)
         .build();
 
     let ref_sample = Sample::from_r1_path(&opts.r1_fastq, REF_PREFIX)?;


### PR DESCRIPTION
Uses commas to delimit large numbers:

```text
[2022-08-08T01:24:17Z INFO  fqgrep] Creating reader threads
[2022-08-08T01:24:17Z INFO  fqgrep] Processing reads
[2022-08-08T01:24:47Z INFO  proglog] [fqgrep-progress] Searched 50,000,000 reads
```