### PR TITLE
Make fqgrep more grep-like in its options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fgoxide"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d571c2c4fb6b56ada5b136196eb40aa4b4e22ae7ca2efb7eb2f8d45e6c13c297"
+dependencies = [
+ "csv",
+ "flate2",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +371,7 @@ dependencies = [
  "built",
  "csv",
  "env_logger",
+ "fgoxide",
  "flate2",
  "flume",
  "gzp",
@@ -363,9 +385,11 @@ dependencies = [
  "proglog",
  "rayon",
  "regex",
+ "rstest",
  "seq_io",
  "serde",
  "structopt",
+ "tempfile",
 ]
 
 [[package]]
@@ -853,6 +877,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rstest"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d912f35156a3f99a66ee3e11ac2e0b3f34ac85a07e05263d05a7e2c8810d616f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,6 +1035,20 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fastrand",
+ "libc",
+ "redox_syscall 0.2.16",
+ "remove_dir_all",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "termcolor"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +140,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -174,7 +192,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -183,7 +201,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -197,7 +215,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -207,7 +225,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -219,7 +237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "memoffset",
  "once_cell",
@@ -232,7 +250,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -242,7 +260,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "once_cell",
 ]
 
@@ -325,7 +343,9 @@ dependencies = [
 name = "fqgrep"
 version = "0.1.1-alpha.1"
 dependencies = [
+ "ansi_term",
  "anyhow",
+ "bitvec",
  "bstr",
  "built",
  "csv",
@@ -333,6 +353,7 @@ dependencies = [
  "flate2",
  "flume",
  "gzp",
+ "isatty",
  "itertools",
  "lazy_static",
  "log",
@@ -346,6 +367,12 @@ dependencies = [
  "serde",
  "structopt",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-core"
@@ -365,7 +392,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "libc",
  "wasi",
@@ -443,7 +470,19 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "isatty"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31a8281fc93ec9693494da65fbf28c0c2aa60a2eaec25dc58e2f31952e95edc"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "redox_syscall 0.1.57",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -569,7 +608,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -653,10 +692,10 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -746,6 +785,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rayon"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +813,12 @@ dependencies = [
  "crossbeam-utils",
  "num_cpus",
 ]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
@@ -925,6 +976,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,7 +1124,7 @@ version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -1157,3 +1214,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,16 @@ path = "src/main.rs"
 lto = true
 
 [dependencies]
+ansi_term = "0.12.1"
 anyhow = "1.0.44"
+bitvec = "1.0.1"
 bstr = "0.2.17"
 csv = "1.1.6"
 env_logger = "0.9.0"
 flate2 = {version = "1.0.22", default-features = false, features = ["zlib-ng-compat"]}
 flume = "0.10.9"
 gzp = "0.9.1"
+isatty = "0.1.9"
 itertools = "0.10.3"
 lazy_static = "1.4.0"
 log = "0.4.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,14 @@ readme = "README.md"
 categories = ["science"]
 keywords = ["bioinformatics", "fastq"]
 
+[lib]
+name = "fqgrep_lib"
+path = "src/lib/mod.rs"
+
+[[bin]]
+name = "fqgrep"
+path = "src/main.rs"
+
 
 [profile.release]
 lto = true
@@ -24,7 +32,7 @@ env_logger = "0.9.0"
 flate2 = {version = "1.0.22", default-features = false, features = ["zlib-ng-compat"]}
 flume = "0.10.9"
 gzp = "0.9.1"
-itertools = "0.10.1"
+itertools = "0.10.3"
 lazy_static = "1.4.0"
 log = "0.4.14"
 mimalloc = {version = "0.1.26", default-features = false}
@@ -32,7 +40,7 @@ num_cpus = "1.13.0"
 parking_lot = "0.11.2"
 proglog = {version = "0.3.0", features = ["pretty_counts"]}
 rayon = "1.5.1"
-regex = "1.5.4"
+regex = "1.6.0"
 seq_io = "0.3.1"
 serde = {version = "1.0.130", features = ["derive"]}
 structopt = "0.3.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,9 @@ structopt = "0.3.23"
 
 [build-dependencies]
 built = {version ="0.5.1", features = ["git2"]}
+
+[dev-dependencies]
+fgoxide = "0.1.3"
+rstest = "0.12.0"
+seq_io = "0.3.1"
+tempfile = "3"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.64.0"
+components = ["rustfmt", "clippy"]

--- a/src/lib/color.rs
+++ b/src/lib/color.rs
@@ -1,0 +1,36 @@
+use ansi_term::Color;
+
+use lazy_static::lazy_static;
+
+lazy_static! {
+    /// Color for matching bases in a FASTQ
+    pub static ref COLOR_BASES: Color = Color::Red;
+    /// Color for matching base qualities in a FASTQ
+    pub static ref COLOR_QUALS: Color = Color::Fixed(22);
+    /// Color for a matching read name (head) of a FASTQ
+    pub static ref COLOR_HEAD: Color = Color::Fixed(30);
+    /// Color for all non-matching text in a FASTQ
+    pub static ref COLOR_BACKGROUND: Color = Color::Fixed(240);
+}
+
+/// Colors the text with the given color
+pub fn color(text: &[u8], colour: &Color) -> Vec<u8> {
+    let mut colored: Vec<u8> = Vec::with_capacity(text.len());
+    colour.paint(text).write_to(&mut colored).unwrap();
+    colored
+}
+
+/// Color for the read name (head) of a FASTQ
+pub fn color_head(text: &[u8]) -> Vec<u8> {
+    color(text, &COLOR_HEAD)
+}
+
+/// Color for the base qualities of a FASTQ
+pub fn color_quals(text: &[u8]) -> Vec<u8> {
+    color(text, &COLOR_QUALS)
+}
+
+/// Color for non-matching bases, quals, and other text
+pub fn color_background(text: &[u8]) -> Vec<u8> {
+    color(text, &COLOR_BACKGROUND)
+}

--- a/src/lib/color.rs
+++ b/src/lib/color.rs
@@ -1,17 +1,13 @@
 use ansi_term::Color;
 
-use lazy_static::lazy_static;
-
-lazy_static! {
-    /// Color for matching bases in a FASTQ
-    pub static ref COLOR_BASES: Color = Color::Red;
-    /// Color for matching base qualities in a FASTQ
-    pub static ref COLOR_QUALS: Color = Color::Fixed(22);
-    /// Color for a matching read name (head) of a FASTQ
-    pub static ref COLOR_HEAD: Color = Color::Fixed(30);
-    /// Color for all non-matching text in a FASTQ
-    pub static ref COLOR_BACKGROUND: Color = Color::Fixed(240);
-}
+/// Color for matching bases in a FASTQ
+pub const COLOR_BASES: Color = Color::Red;
+/// Color for matching base qualities in a FASTQ
+pub const COLOR_QUALS: Color = Color::Fixed(22);
+/// Color for a matching read name (head) of a FASTQ
+pub const COLOR_HEAD: Color = Color::Fixed(30);
+/// Color for all non-matching text in a FASTQ
+pub const COLOR_BACKGROUND: Color = Color::Fixed(240);
 
 /// Colors the text with the given color
 pub fn color(text: &[u8], colour: &Color) -> Vec<u8> {

--- a/src/lib/matcher.rs
+++ b/src/lib/matcher.rs
@@ -230,7 +230,7 @@ impl Matcher for FixedStringSetMatcher {
     fn bases_match(&self, bases: &[u8]) -> bool {
         self.patterns
             .iter()
-            .any(|pattern| bases.find(&pattern).is_some())
+            .any(|pattern| bases.find(pattern).is_some())
             != self.opts.invert_match
     }
 
@@ -405,5 +405,222 @@ impl MatcherFactory {
             (true, None) => Box::new(FixedStringSetMatcher::new(regexp, match_opts)),
             (false, None) => Box::new(RegexSetMatcher::new(regexp, match_opts)),
         }
+    }
+}
+
+// Tests
+#[cfg(test)]
+pub mod tests {
+    use crate::matcher::*;
+    use rstest::rstest;
+
+    /// Helper function takes a sequence and returns a seq_io::fastq::OwnedRecord
+    ///
+    fn write_owned_record(seq: &str) -> OwnedRecord {
+        let read = OwnedRecord {
+            head: ("@Sample").as_bytes().to_vec(),
+            seq: seq.as_bytes().to_vec(),
+            qual: vec![b'X'; seq.len()],
+        };
+        read
+    }
+
+    // ############################################################################################
+    // Tests to_bitvec()
+    // ############################################################################################
+
+    #[rstest]
+    #[case(vec![(0, 1)], "AGG",  bitvec![1, 0, 0])] // single range that starts at the beginning of the read
+    #[case(vec![(2, 3)], "AGG", bitvec![0, 0, 1])] // single range that ends at the ends of the read
+    #[case(vec![(1, 2)], "AGG", bitvec![0, 1, 0])] // single range of a single base
+    #[case(vec![(0 ,0)], "AGG", bitvec![0, 0, 0])] // empty set of ranges
+    #[case(vec![(0, 3)], "AGG", bitvec![1, 1, 1])] // single range that encompasses the full read
+    #[case(vec![(1, 4)], "AGGTC", bitvec![0, 1, 1, 1, 0])] // single range in the "middle" of the read
+    #[case(vec![(0, 2), (3, 5)], "AGGTC", bitvec![1, 1, 0, 1, 1])] // two ranges non-overlapping
+    #[case(vec![(0, 3), (3, 5)], "AGGTC", bitvec![1, 1, 1, 1, 1])] // two ranges abutting
+    #[case(vec![(0, 4), (3, 5)], "AGGTC", bitvec![1, 1, 1, 1, 1])] // two ranges overlapping
+    #[case(vec![(0, 3), (0, 5)], "AGGTC", bitvec![1, 1, 1, 1, 1])] // two ranges, one containing the other
+    #[case(vec![(4, 5), (0, 2)], "AGGTC", bitvec![1, 1, 0, 0, 1])] // multiple ranges, but not in sorted order
+    fn test_to_bitvec(
+        #[case] ranges: Vec<(usize, usize)>,
+        #[case] bases: &str,
+        #[case] expected: BitVec,
+    ) {
+        let ranges = ranges
+            .into_iter()
+            .map(|(start, end)| std::ops::Range { start, end });
+        let result_bitvec = to_bitvec(ranges, bases.len());
+        assert_eq!(result_bitvec, expected);
+    }
+
+    // ############################################################################################
+    // Test FixedStringMatcher::read_match()
+    // ############################################################################################
+
+    #[rstest]
+    #[case(false, "AG", "AGG", true)] // fixed string with match when reverse_complement is false
+    #[case(false, "CC", "AGG", false)] // fixed string with no match when reverse_complement is false
+    #[case(true, "CC", "AGG", true)] // fixed string with match when reverse_complement is true
+    #[case(true, "TT", "AGG", false)] // fixed string with no match when reverse_complement is true
+    #[case(false, "AT", "ATGAT", true)] // fixed string with multiple non-overlapping matches when reverse_complement is false
+    #[case(true, "CG", "GCCG", true)] // fixed string with multiple non-overlapping matches when reverse_complement is true
+    #[case(false, "AGAG", "AGAGAGAG", true)] // fixed string with overlapping matches when reverse_complemet is false
+    #[case(true, "TCTC", "AGAGAGAG", true)] // fixed string with overlapping matches when reverse_complemet is true
+    fn test_fixed_string_matcher_read_match(
+        #[case] reverse_complement: bool,
+        #[case] pattern: &str,
+        #[case] seq: &str,
+        #[case] expected: bool,
+    ) {
+        let invert_matches = [true, false];
+        for invert_match in IntoIterator::into_iter(invert_matches).to_owned() {
+            let opts = MatcherOpts {
+                invert_match,
+                reverse_complement,
+                color: false,
+            };
+            let matcher = FixedStringMatcher::new(pattern, opts);
+            let mut read_record = write_owned_record(seq);
+            let result = matcher.read_match(&mut read_record);
+            if invert_match {
+                assert_ne!(result, expected);
+            } else {
+                assert_eq!(result, expected);
+            }
+        }
+    }
+
+    // ############################################################################################
+    // Tests FixedStringSetMatcher::read_match()
+    // ############################################################################################
+
+    #[rstest]
+    #[case(false, vec!["A", "AGG", "G"], "AGGG", true)] // match is true when reverse_complement is false
+    #[case(true, vec!["A", "AGG", "G"], "TCCC", true)] // match is true when reverse_complement is true
+    #[case(false, vec!["A", "AGG", "G"], "TTTT", false)] // match is false when reverse_complement is false
+    #[case(true, vec!["T", "AAA"], "CCCCC", false)] // match is false when reverse_complement is true
+    #[case(false, vec!["AGG", "C", "TT"], "AGGTT",  true)] // match is true but not all patterns match when reverse_complement is false
+    #[case(true, vec!["AGG", "C", "TT"], "GGGGG",  true)] // match is true but not all patterns match when reverse_complement is true
+    #[case(false, vec!["AC", "TT"], "TTACGTT",  true)] // match is true but one pattern matches multiple times when reverse_complement is false
+    #[case(true, vec!["GT", "AA"], "TTACGTT",  true)] // match is true but one pattern matches multiple times when reverse_complement is true
+    #[case(false, vec!["GAGA","AGTT"], "GAGAGTT",  true)] // match is true with overlapping matches when reverse_complment is false
+    #[case(true, vec!["CTCT","AACT"], "GAGAGTT",  true)] // match is true with overlapping matches when reverse_complment is true
+    fn test_fixed_string_set_metcher_read_match(
+        #[case] reverse_complement: bool,
+        #[case] patterns: Vec<&str>,
+        #[case] seq: &str,
+        #[case] expected: bool,
+    ) {
+        let invert_matches = [true, false];
+        for invert_match in IntoIterator::into_iter(invert_matches).to_owned() {
+            let opts = MatcherOpts {
+                invert_match,
+                reverse_complement,
+                color: false,
+            };
+            let matcher = FixedStringSetMatcher::new(patterns.iter(), opts);
+            let mut read_record = write_owned_record(seq);
+            let result = matcher.read_match(&mut read_record);
+            if invert_match {
+                assert_ne!(result, expected);
+            } else {
+                assert_eq!(result, expected);
+            }
+        }
+    }
+
+    // ############################################################################################
+    // Test RegexMatcher::read_match()
+    // ############################################################################################
+
+    #[rstest]
+    #[case(false, "^A", "AGG", true)] // regex with one match when reverse_complement is false
+    #[case(false, "^T", "AGG", false)] // regex with no matches when reverse_complement is false
+    #[case(true, "^C", "AGG", true)] // regex with one match when reverse_complement is true
+    #[case(true, "^T", "AGG", false)] // regex with no matches when reverse_complement is true
+    #[case(false, "A.A", "ATATA", true)] // regex with overlapping matches when reverse_complement is false
+    #[case(true, "T.G", "CACACA", false)] // regex with overlapping matches when reverse_complement is true
+    fn test_regex_matcher_read_match(
+        #[case] reverse_complement: bool,
+        #[case] pattern: &str,
+        #[case] seq: &str,
+        #[case] expected: bool,
+    ) {
+        let invert_matches = [true, false];
+        for invert_match in IntoIterator::into_iter(invert_matches).to_owned() {
+            let opts = MatcherOpts {
+                invert_match,
+                reverse_complement,
+                color: false,
+            };
+
+            let matcher = RegexMatcher::new(&pattern, opts);
+            let mut read_record = write_owned_record(seq);
+            let result = matcher.read_match(&mut read_record);
+            if invert_match {
+                assert_ne!(result, expected);
+            } else {
+                assert_eq!(result, expected);
+            }
+        }
+    }
+
+    // ############################################################################################
+    // Tests RegexSetMatcher::read_match()
+    // ############################################################################################
+
+    #[rstest]
+    #[case(false, vec!["^A.G", "C..", "$T"], "AGGCTT", true)] // match is true when reverse_complement is false
+    #[case(true, vec!["^T.C", "..G", "$A"], "AGGCTT", true)] // match is true when reverse_complement is true
+    #[case(false, vec!["^A.G", "G..", "$T"], "CCTCA", false)] // match is false when reverse_complemet is false
+    #[case(true, vec!["$A", "C.CC"], "CCTCA", false)] // match is false when reverse_complemet is true
+    #[case(false, vec!["^T", ".GG", "A.+G"],  "ATCTACTACG",  true)] // match is true but not all patterns match when reverse_complement is false
+    #[case(true, vec!["^C", ".CC", "C+.T"],  "ATCTACTACG",  true)] // match is true when reverse_complement is true
+    #[case(false, vec!["^T", "T.A"], "TTAATAA", true)] // match is true but one pattern matches multiple times when reverse_complement is false
+    #[case(true, vec!["^T", "T.A"], "AATA", true)] // match is true but one pattern matches multiple times when reverse_complemetn is true
+    #[case(false, vec!["^T","T.+G"], "TAGAGTG",  true)] // match is true with overlapping matches when reverse_complement is false
+    #[case(true, vec!["^A","A.+C"], "TAGAGTG",  true)] // match is true with overlapping matches when reverse_complement is true
+    fn test_regex_set_metcher_read_match(
+        #[case] reverse_complement: bool,
+        #[case] patterns: Vec<&str>,
+        #[case] seq: &str,
+        #[case] expected: bool,
+    ) {
+        let invert_matches = [true, false];
+        for invert_match in IntoIterator::into_iter(invert_matches).to_owned() {
+            let opts = MatcherOpts {
+                invert_match,
+                reverse_complement,
+                color: false,
+            };
+
+            let matcher = RegexSetMatcher::new(patterns.iter(), opts);
+            let mut read_record = write_owned_record(seq);
+            let result = matcher.read_match(&mut read_record);
+            if invert_match {
+                assert_ne!(result, expected);
+            } else {
+                assert_eq!(result, expected);
+            }
+        }
+    }
+
+    // ############################################################################################
+    // Tests validate_fixed_pattern()
+    // ############################################################################################
+
+    #[test]
+    fn test_validate_fixed_pattern_is_ok() {
+        let pattern = "AGTGTGATG";
+        let result = validate_fixed_pattern(&pattern);
+        assert!(result.is_ok())
+    }
+    #[test]
+    fn test_validate_fixed_pattern_error() {
+        let pattern = "AXGTGTGATG";
+        let msg = String::from("Fixed pattern must contain only DNA bases: A .. [X] .. GTGTGATG");
+        let result = validate_fixed_pattern(&pattern);
+        let inner = result.unwrap_err().to_string();
+        assert_eq!(inner, msg);
     }
 }

--- a/src/lib/matcher.rs
+++ b/src/lib/matcher.rs
@@ -337,7 +337,6 @@ impl Matcher for RegexSetMatcher {
 }
 
 /// Factory for building a matcher
-///
 pub struct MatcherFactory;
 
 impl MatcherFactory {

--- a/src/lib/matcher.rs
+++ b/src/lib/matcher.rs
@@ -1,0 +1,145 @@
+use crate::reverse_complement;
+use crate::DNA_BASES;
+use anyhow::{bail, Context, Result};
+use bstr::ByteSlice;
+use regex::bytes::{Regex, RegexBuilder, RegexSet, RegexSetBuilder};
+use seq_io::fastq::{OwnedRecord, Record};
+
+#[derive(Copy, Clone, Debug)]
+pub struct MatcherOpts {
+    pub invert_match: bool,
+    pub reverse_complement: bool,
+}
+
+pub trait Matcher {
+    fn opts(&self) -> MatcherOpts;
+
+    fn bases_match(&self, bases: &[u8]) -> bool;
+
+    fn read_match(&self, read: &OwnedRecord) -> bool {
+        if self.opts().invert_match {
+            self.bases_match(read.seq())
+                && (self.opts().reverse_complement
+                    && self.bases_match(&reverse_complement(read.seq())))
+        } else {
+            self.bases_match(read.seq())
+                || (self.opts().reverse_complement
+                    && self.bases_match(&reverse_complement(read.seq())))
+        }
+    }
+}
+
+pub struct FixedStringMatcher {
+    pattern: Vec<u8>,
+    opts: MatcherOpts,
+}
+
+impl Matcher for FixedStringMatcher {
+    fn bases_match(&self, bases: &[u8]) -> bool {
+        bases.find(&self.pattern).is_some() != self.opts.invert_match
+    }
+    fn opts(&self) -> MatcherOpts {
+        self.opts
+    }
+}
+
+impl FixedStringMatcher {
+    pub fn new(pattern: &str, opts: MatcherOpts) -> Self {
+        let pattern = pattern.as_bytes().to_vec();
+        Self { pattern, opts }
+    }
+
+    pub fn validate(pattern: &str) -> Result<()> {
+        for (index, base) in pattern.chars().enumerate() {
+            if !DNA_BASES.contains(&(base as u8)) {
+                bail!(
+                    "Fixed pattern must contain only DNA bases: {} .. [{}] .. {}",
+                    &pattern[0..index],
+                    &pattern[index..=index],
+                    &pattern[index + 1..],
+                )
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct FixedStringSetMatcher {
+    patterns: Vec<Vec<u8>>,
+    opts: MatcherOpts,
+}
+
+impl Matcher for FixedStringSetMatcher {
+    fn bases_match(&self, bases: &[u8]) -> bool {
+        self.patterns
+            .iter()
+            .any(|pattern| bases.find(&pattern).is_some())
+            != self.opts.invert_match
+    }
+    fn opts(&self) -> MatcherOpts {
+        self.opts
+    }
+}
+
+impl FixedStringSetMatcher {
+    pub fn new<I, S>(patterns: I, opts: MatcherOpts) -> Self
+    where
+        S: AsRef<str>,
+        I: IntoIterator<Item = S>,
+    {
+        let patterns: Vec<Vec<u8>> = patterns
+            .into_iter()
+            .map(|pattern| pattern.as_ref().to_owned().as_bytes().to_vec())
+            .collect();
+        Self { patterns, opts }
+    }
+}
+
+pub struct RegexMatcher {
+    regex: Regex,
+    opts: MatcherOpts,
+}
+
+impl RegexMatcher {
+    pub fn new(pattern: &str, opts: MatcherOpts) -> Self {
+        let regex = RegexBuilder::new(pattern)
+            .build()
+            .context(format!("Invalid regular expression: {}", pattern))
+            .unwrap();
+        Self { regex, opts }
+    }
+}
+
+impl Matcher for RegexMatcher {
+    fn bases_match(&self, bases: &[u8]) -> bool {
+        self.regex.is_match(bases) != self.opts.invert_match
+    }
+    fn opts(&self) -> MatcherOpts {
+        self.opts
+    }
+}
+
+pub struct RegexSetMatcher {
+    regexes: RegexSet,
+    opts: MatcherOpts,
+}
+
+impl RegexSetMatcher {
+    pub fn new<I, S>(patterns: I, opts: MatcherOpts) -> Self
+    where
+        S: AsRef<str>,
+        I: IntoIterator<Item = S>,
+    {
+        let regexes = RegexSetBuilder::new(patterns).build().unwrap();
+        Self { regexes, opts }
+    }
+}
+
+impl Matcher for RegexSetMatcher {
+    fn bases_match(&self, bases: &[u8]) -> bool {
+        self.regexes.is_match(bases) != self.opts.invert_match
+    }
+    fn opts(&self) -> MatcherOpts {
+        self.opts
+    }
+}

--- a/src/lib/matcher.rs
+++ b/src/lib/matcher.rs
@@ -151,8 +151,8 @@ pub trait Matcher {
     fn read_match(&self, read: &mut OwnedRecord) -> bool {
         let match_found = if self.opts().invert_match {
             self.bases_match(read.seq())
-                && (self.opts().reverse_complement
-                    && self.bases_match(&reverse_complement(read.seq())))
+                && (!self.opts().reverse_complement
+                    || self.bases_match(&reverse_complement(read.seq())))
         } else {
             self.bases_match(read.seq())
                 || (self.opts().reverse_complement

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -71,3 +71,54 @@ const FASTQ_EXTENSIONS: [&str; 2] = ["fastq", "fq"];
 pub fn is_fastq_path<P: AsRef<Path>>(p: &P) -> bool {
     is_path_with_extension(p, FASTQ_EXTENSIONS)
 }
+
+// Tests
+#[cfg(test)]
+pub mod tests {
+    use crate::*;
+    use rstest::rstest;
+    use std::str;
+    use tempfile::TempDir;
+
+    // ############################################################################################
+    // Tests reverse_complement()
+    // ############################################################################################
+
+    #[rstest]
+    #[case("ACGT", "ACGT")] // Reverse complement with even length string
+    #[case("ACG", "CGT")] // Reverse complement with odd length string (tests for off by one error)
+    fn test_reverse_complement(#[case] seq: &str, #[case] expected: &str) {
+        let result = reverse_complement(seq.as_bytes());
+        let string_result = str::from_utf8(&result).unwrap();
+        assert_eq!(&string_result, &expected);
+    }
+
+    // ############################################################################################
+    // Tests is_gzip_path()
+    // ############################################################################################
+
+    #[rstest]
+    #[case("test_fastq.fq.gz", true)] // .fq.gz is valid gzip
+    #[case("test_fastq.fq.bgz", true)] // .fq.bgz is valid gzip
+    #[case("test_fastq.fq.tar", false)] // .fq.tar is invalid gzip
+    fn test_is_gzip_path(#[case] file_name: &str, #[case] expected: bool) {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join(file_name);
+        let result = is_gzip_path(&file_path);
+        assert_eq!(result, expected);
+    }
+    // ############################################################################################
+    // Tests is_fastq_path()
+    // ############################################################################################
+
+    #[rstest]
+    #[case("test_fastq.fq", true)] // .fq is valid fastq
+    #[case("test_fastq.fastq", true)] // .fastq is valid fastq
+    #[case("test_fastq.sam", false)] // .sam is invalid fastq
+    fn test_is_fastq_path(#[case] file_name: &str, #[case] expected: bool) {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join(file_name);
+        let result = is_fastq_path(&file_path);
+        assert_eq!(result, expected);
+    }
+}

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -10,31 +10,11 @@ pub mod matcher;
 use lazy_static::lazy_static;
 use std::{borrow::Borrow, path::Path};
 
+pub const DNA_BASES: [u8; 5] = *b"ACGTN";
+pub const IUPAC_BASES: [u8; 15] = *b"AGCTYRWSKMDVHBN";
+pub const IUPAC_BASES_COMPLEMENT: [u8; 15] = *b"TCGARYWSMKHBDVN";
+
 lazy_static! {
-    pub static ref DNA_BASES: [u8; 5] = {
-        let mut bases = [0; 5];
-        for (i, base) in b"ACGTN".iter().enumerate() {
-            bases[i] = *base;
-        }
-        bases
-    };
-
-    pub static ref IUPAC_BASES: [u8;15] = {
-        let mut bases = [0; 15];
-        for (i, base) in b"AGCTYRWSKMDVHBN".iter().enumerate() {
-            bases[i] = *base;
-        }
-        bases
-    };
-
-    pub static ref IUPAC_BASES_COMPLEMENT: [u8;15] = {
-        let mut bases = [0; 15];
-        for (i, base) in b"TCGARYWSMKHBDVN".iter().enumerate() {
-            bases[i] = *base;
-        }
-        bases
-    };
-
     pub static ref COMPLEMENT: [u8; 256] = {
         let mut comp = [0; 256];
         for (v, a) in comp.iter_mut().enumerate() {

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,0 +1,64 @@
+#![deny(unsafe_code)]
+#![allow(
+    clippy::must_use_candidate,
+    clippy::missing_panics_doc,
+    clippy::missing_errors_doc,
+    clippy::module_name_repetitions
+)]
+pub mod matcher;
+use lazy_static::lazy_static;
+use std::borrow::Borrow;
+
+lazy_static! {
+    pub static ref DNA_BASES: [u8; 5] = {
+        let mut bases = [0; 5];
+        for (i, base) in b"ACGTN".iter().enumerate() {
+            bases[i] = *base;
+        }
+        bases
+    };
+
+    pub static ref IUPAC_BASES: [u8;15] = {
+        let mut bases = [0; 15];
+        for (i, base) in b"AGCTYRWSKMDVHBN".iter().enumerate() {
+            bases[i] = *base;
+        }
+        bases
+    };
+
+    pub static ref IUPAC_BASES_COMPLEMENT: [u8;15] = {
+        let mut bases = [0; 15];
+        for (i, base) in b"TCGARYWSMKHBDVN".iter().enumerate() {
+            bases[i] = *base;
+        }
+        bases
+    };
+
+    pub static ref COMPLEMENT: [u8; 256] = {
+        let mut comp = [0; 256];
+        for (v, a) in comp.iter_mut().enumerate() {
+            *a = v as u8;
+        }
+        for (&a, &b) in IUPAC_BASES.iter().zip(IUPAC_BASES_COMPLEMENT.iter()) {
+            comp[a as usize] = b;
+            comp[a as usize + 32] = b + 32;  // lowercase variants
+        }
+        comp
+    };
+}
+
+fn complement(a: u8) -> u8 {
+    COMPLEMENT[a as usize]
+}
+
+fn reverse_complement<C, T>(text: T) -> Vec<u8>
+where
+    C: Borrow<u8>,
+    T: IntoIterator<Item = C>,
+    T::IntoIter: DoubleEndedIterator,
+{
+    text.into_iter()
+        .rev()
+        .map(|a| complement(*a.borrow()))
+        .collect()
+}

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -5,6 +5,7 @@
     clippy::missing_errors_doc,
     clippy::module_name_repetitions
 )]
+pub mod color;
 pub mod matcher;
 use lazy_static::lazy_static;
 use std::{borrow::Borrow, path::Path};

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -7,7 +7,7 @@
 )]
 pub mod matcher;
 use lazy_static::lazy_static;
-use std::borrow::Borrow;
+use std::{borrow::Borrow, path::Path};
 
 lazy_static! {
     pub static ref DNA_BASES: [u8; 5] = {
@@ -61,4 +61,32 @@ where
         .rev()
         .map(|a| complement(*a.borrow()))
         .collect()
+}
+
+/// Returns true if the path ends with a recognized GZIP file extension
+fn is_path_with_extension<P: AsRef<Path>>(p: &P, extensions: [&str; 2]) -> bool {
+    if let Some(ext) = p.as_ref().extension() {
+        match ext.to_str() {
+            Some(x) => extensions.contains(&x),
+            None => false,
+        }
+    } else {
+        false
+    }
+}
+
+/// The set of file extensions to treat as GZIPPED
+const GZIP_EXTENSIONS: [&str; 2] = ["gz", "bgz"];
+
+/// Returns true if the path ends with a recognized GZIP file extension
+pub fn is_gzip_path<P: AsRef<Path>>(p: &P) -> bool {
+    is_path_with_extension(p, GZIP_EXTENSIONS)
+}
+
+/// The set of file extensions to treat as FASTQ
+const FASTQ_EXTENSIONS: [&str; 2] = ["fastq", "fq"];
+
+/// Returns true if the path ends with a recognized FASTQ file extension
+pub fn is_fastq_path<P: AsRef<Path>>(p: &P) -> bool {
+    is_path_with_extension(p, FASTQ_EXTENSIONS)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,6 +333,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::borrowed_box)] // FIXME: remove me later and solve
 fn process_paired_reads(
     reads: Vec<(OwnedRecord, OwnedRecord)>,
     matcher: &Box<dyn Matcher + Sync>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,11 +202,9 @@ arg_enum! {
 /// input and any unrecongized inputs as plaintext (uncompressed).
 ///
 /// EXIT STATUS
-///      The fqgrep utility exits with one of the following values:
 ///
-///      0     One or more lines were selected.
-///      1     No lines were selected.
-///      >1    An error occurred.
+/// The fqgrep utility exits with one of the following values:
+/// 0 if one or more lines were selected, 1 if no lines were selected, and >1 if an error occurred.
 ///
 #[derive(StructOpt, Debug)]
 #[structopt(
@@ -236,7 +234,7 @@ struct Opts {
     #[structopt(long, short = "e")]
     regexp: Vec<String>,
 
-    // Interpret pattern as a set of fixed strings
+    /// Interpret pattern as a set of fixed strings
     #[structopt(long, short = "F")]
     fixed_strings: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,7 +164,8 @@ struct Opts {
 
     /// Treat the input files as paired.  The number of input files must be a multiple of two,
     /// with the first file being R1, second R2, third R1, fourth R2, and so on.  If the pattern
-    /// matches either R1 or R2, then both R1 and R2 will be output (interleaved).
+    /// matches either R1 or R2, then both R1 and R2 will be output (interleaved).  If the input
+    /// is standard input, then treat the input as interlaved paired end reads.
     #[structopt(long)]
     paired: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ use std::{
     io::{BufRead, BufReader, BufWriter, Read, Write},
     path::PathBuf,
     str::FromStr,
-    thread::JoinHandle,
 };
 
 use anyhow::{bail, ensure, Context, Result};
@@ -21,7 +20,7 @@ use itertools::{self, izip, Itertools};
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use proglog::{CountFormatterKind, ProgLog, ProgLogBuilder};
-use rayon::{prelude::*, Scope, ThreadPool};
+use rayon::{prelude::*, ThreadPool};
 use seq_io::fastq::{self, OwnedRecord, Record};
 use structopt::{clap::AppSettings, StructOpt};
 


### PR DESCRIPTION
This adds a ton of changes:

1. All reader, writer, and matching threads use a rayon thread pool.  This means that `--threads` is respected.  Previously reader and writer threads were always allocated outside the match pool, and there were specific arguments for the latter and compressing the output (the latter feature has been removed, plaintext FASTQ is the only output format, just pipe it if you need to).
2. Takes in a pattern as the first positional argument, which is now a regular expression (previously a fixed string).
3. Takes in zero or more file paths after the positional argument.  Uses standard input if no file are given positionally or with `-f` below.
4. Input files are assumed to be plain uncompressed FASTQs unless the `--decompress` option is given, in which case they're assumed to be GZIP compressed.  This includes standard input.  The exception are `.gz/.bgz` and`.fastq/.fq` which are always treated as GZIP compressed and plain text respectively.
5. Implement the following options from grep:

* `-c, --count`: simply return the count of matching records
* `-F, --fixed-strings`: interpret pattern as a set of fixed strings
* `-v`: Selected records are those not matching any of the specified patterns
* `--color <color>`: color the output records with ANSI color codes
* `-e, --regexp <regexp>...`: specify the pattern used during the search.  Can be specified multiple times
* `-f, --file <file>`: Read one or more newline separated patterns from file.
* `-Z, --decompress`: treat all non `.gz`, `.bgz`, `.fastq`, and `.fq` files as GZIP compressed (default treat as uncompressed)

6. The exit code follows GREP, where we exit with 0 if one or more lines were selected, 1 if no lines were selected, and >1 if an error occurred.
7.  Add non-grep options:

* `--paired`: if one file or standard input is used, treat the input as an _interleaved_ paired end FASTQ.  If more than one file is given, ensure that the number of files are a multiple of two, and treat each consecutive pair of files as R1 and R2 respectively.  If the pattern matches either R1 _or_ R2, output both (interleaved FASTQ).
* `--reverse-complement`: searches the reverse complement of the read sequences in addition
* `--progress`: write progress (counts of records searched)
* `-t, --threads <threads>`: see (1) above

This could use a lot of unit tests and some test on large datasets (to ensure correctness and performance relative to the previous version)
