### PR TITLE
Add a rust-toolchain file.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.64.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Wouldn't build on my machine, which was defaulting to an older rust version, due to a feature being stabilized that you rely on.