### PR TITLE
Tests fqgrep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/backup
+/test_input

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fgoxide"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d571c2c4fb6b56ada5b136196eb40aa4b4e22ae7ca2efb7eb2f8d45e6c13c297"
+dependencies = [
+ "csv",
+ "flate2",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +371,7 @@ dependencies = [
  "built",
  "csv",
  "env_logger",
+ "fgoxide",
  "flate2",
  "flume",
  "gzp",
@@ -366,7 +388,15 @@ dependencies = [
  "seq_io",
  "serde",
  "structopt",
+ "tempdir",
+ "tempfile",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -791,6 +821,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
 name = "rayon"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +870,15 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -851,6 +918,15 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "ryu"
@@ -980,6 +1056,30 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand",
+ "remove_dir_all",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fastrand",
+ "libc",
+ "redox_syscall 0.2.16",
+ "remove_dir_all",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,14 @@ regex = "1.6.0"
 seq_io = "0.3.1"
 serde = {version = "1.0.130", features = ["derive"]}
 structopt = "0.3.23"
+tempfile = "3.2.0"
+tempdir = "0.3"
+fgoxide = "0.1.3"
 
 [build-dependencies]
 built = {version ="0.5.1", features = ["git2"]}
+
+[dev-dependencies]
+tempfile = "3.2.0"
+tempdir = "0.3"
+fgoxide = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,5 @@ fgoxide = "0.1.3"
 built = {version ="0.5.1", features = ["git2"]}
 
 [dev-dependencies]
-tempfile = "3.2.0"
 tempdir = "0.3"
 fgoxide = "0.1.3"


### PR DESCRIPTION
Added test mod to main.rs and added hidden option --output:

- --output hidden option implemented in StructOpts and called in testing: takes Option<PathBuf>
- Added lines (80 - 98) to create 'maybe_writer' as None if --count, to a file if --output, else to stdout
- Amended line 417 to include 'opts.output' when calling FastqWriter::new()
- fqgrep_from_opts() was added so that an instance of StuctOpts could be passed to what was fqgrep() as a parameter
- fqgrep() was amended to call fqgrep_from_opts() after creating opts using setup()

Test Mod Helpers:

- write_fastq() helper function that generates fastq files from provided sequences in a temp directory
- write_pattern() helper function that generates a .txt file with regex patterns in a temp directory
- call_opts() helper function that creates an instance of StructOpts with the regex coming from either a PathBuf or a Vec<String>
- write_opts() helper function that actually returns an instance of StructOpts

Tests:

- **test_single_fq()** 
- pattern = "^A" or "^G" from opts.regexp
- fastq structure = one fastq with two sequences - "AAGTCTGAATCCATGGAAAGCTATTG", "GGGTCTGAATCCATGGAAAGCTATTG"
- looking for a return match count of 2

- ** test_multiple_fq()**
- pattern = "^A" or "^G" from opts.file
- fastq structure = two fastq each with two sequences - "AAGTCTGAATCCATGGAAAGCTATTG", "GGGTCTGAATCCATGGAAAGCTATTG"
- opts.paired = true
- looking for a return match count of 2

- **test_get_output()**
- pattern = "^A" from opts.file
- - fastq structure = two fastq one with "AAGTCTGAATCCATGGAAAGCTATTG" the other with "GGGTCTGAATCCATGGAAAGCTATTG"
- opts.options = tempdir/output.fq 
- After calling fqgrep_from_opts() the output file is read into 'lines' where only lines containing sequences are retained ,the expected sequence match is manually defined as 'expected', and 'lines' should be equal to 'expected'. This function needs cleaning. 