### PR TITLE
Updated command-line usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ARGS:
 ## Example Invocation
 
 ```console
-fqgrep --progress --threads 16 --color always <PATTERN> <TEST_1.fastq> <TEST_2.fq> <TEST_3>.fq.gz <TEST_3>.fastq.gz ...
+fqgrep --progress --threads 16 --color always <PATTERN> <TEST_1.fastq> <TEST_2.fq> <TEST_3.fq.gz> <TEST_4.fastq.gz> ...
 ```
 
 ## Help

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   Grep for FASTQ files.
 </p>
 
-Search a pair of fastq files for reads that match a given ref or alt sequence.
+Search fastq files for reads that match a given sequence.
 
 ## Install
 
@@ -29,7 +29,44 @@ cargo install --path .
 ## Usage
 
 ```console
-fqgrep -r 'GACGAGATTA' -a 'GACGTGATTA' --r1-fastq /data/testR1.fastq.gz  --r2-fastq /data/testR2.fastq.gz -o ./test_out -t 28
+fqgrep [FLAGS] [OPTIONS] [--] [args]...
+
+FLAGS:
+    -c, --count                 Only a count of selected lines is written to standard output
+    -F, --fixed-strings         Interpret pattern as a set of fixed strings
+    -v                          Selected lines are those not matching any of the specified patterns
+    -Z, --decompress            Assume all unrecognized inputs are GZIP compressed
+        --paired                Treat the input files as paired.  The number of input files must be a multiple of two,
+                                with the first file being R1, second R2, third R1, fourth R2, and so on.  If the pattern
+                                matches either R1 or R2, then both R1 and R2 will be output (interleaved).  If the input
+                                is standard input, then treat the input as interlaved paired end reads
+        --reverse-complement    Search the reverse complement for matches
+        --progress              Write progress information
+    -h, --help                  Prints help information
+    -V, --version               Prints version information
+
+OPTIONS:
+    -t, --threads <threads>     The number of threads to use for matching reads against pattern.  See the full usage for
+                                threads specific to reading and writing [default: 8]
+        --color <color>         Mark up the matching text.  The possible values of when are “never”, “always” and “auto”
+                                [default: never]
+    -e, --regexp <regexp>...    Specify a pattern used during the search of the input: an input line is selected if it
+                                matches any of the specified patterns.  This option is most useful when multiple `-e`
+                                options are used to specify multiple patterns
+    -f, --file <file>           Read one or more newline separated patterns from file.  Empty pattern lines match every
+                                input line.  Newlines are not considered part of a pattern.  If file is empty, nothing
+                                is matched
+
+ARGS:
+    <args>...    The first argument is the pattern to match, with the remaining arguments containing the files to
+                 match.  If `-e` is given, then all the arguments are files to match. Use standard input if either
+                 no files are given or `-` is given
+```
+
+## Example Invocation
+
+```console
+fqgrep --progress --threads 16 --color always <PATTERN> <TEST_1.fastq> <TEST_2.fq> <TEST_3>.fq.gz <TEST_3>.fastq.gz ...
 ```
 
 ## Help


### PR DESCRIPTION
New command-line usage with full list of accepted parameters and an example invocation of the command. Also slightly edited the tool description to match the vision of mirroring `grep` as closely as possible.