### PR TITLE
use `seq_io::parallel::parallel_fastq` to speed up `fqgrep`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,25 +318,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,7 +450,6 @@ dependencies = [
  "env_logger",
  "fgoxide",
  "flate2",
- "flume",
  "gzp",
  "isatty",
  "itertools",
@@ -480,7 +460,6 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "proglog",
- "rayon",
  "regex",
  "rstest",
  "seq_io",
@@ -1068,26 +1047,6 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
 
 [[package]]
 name = "redox_syscall"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,7 +453,6 @@ dependencies = [
  "gzp",
  "isatty",
  "itertools",
- "lazy_static",
  "libz-ng-sys",
  "log",
  "mimalloc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,9 +183,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cargo-lock"
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_logger"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,8 +1210,7 @@ dependencies = [
 [[package]]
 name = "seq_io"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc89ab65d1924c8cf81ffb9a162b20514bb5c5064e0d2b4c41dbbbfeb52fa5c9"
+source = "git+https://github.com/nh13/seq_io.git?rev=640160566a87b4d26e610a92026600b02218303d#640160566a87b4d26e610a92026600b02218303d"
 dependencies = [
  "buffer-redux",
  "crossbeam-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ flate2 = {version = "1.1.0", default-features = false, features = ["zlib-ng"]}
 gzp = "1.0.1"
 isatty = "0.1.9"
 itertools = "0.10.5"
-lazy_static = "1.5.0"
 libz-ng-sys = "1.1.21"
 log = "0.4.26"
 mimalloc = {version = "0.1.43", default-features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,10 @@ parking_lot = "0.11.2"
 proglog = {version = "0.3.0", features = ["pretty_counts"]}
 rayon = "1.10.0"
 regex = {version = "1.11.1", default-features = false, features = ["perf", "perf-onepass", "perf-inline", "perf-literal"]}
-seq_io = "0.3.3"
+# for https://github.com/markschl/seq_io/pull/23
+#seq_io = "0.3.3"
+seq_io = { git = "https://github.com/nh13/seq_io.git", rev = "640160566a87b4d26e610a92026600b02218303d" }
+
 serde = {version = "1.0.218", features = ["derive"]}
 
 [build-dependencies]
@@ -55,5 +58,5 @@ built = {version ="0.5.2", features = ["git2"]}
 [dev-dependencies]
 fgoxide = "0.5.0"
 rstest = "0.12.0"
-seq_io = "0.3.3"
+seq_io = { git = "https://github.com/nh13/seq_io.git", rev = "640160566a87b4d26e610a92026600b02218303d" }
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ num_cpus = "1.16.0"
 parking_lot = "0.11.2"
 proglog = {version = "0.3.0", features = ["pretty_counts"]}
 rayon = "1.10.0"
-regex = "1.11.1"
+regex = {version = "1.11.1", default-features = false, features = ["perf", "perf-onepass", "perf-inline", "perf-literal"]}
 seq_io = "0.3.3"
 serde = {version = "1.0.218", features = ["derive"]}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ clap = { version = "4.5.31", features = ["derive", "unstable-markdown"] }
 csv = "^1, <1.2"
 env_logger = "0.9.3"
 flate2 = {version = "1.1.0", default-features = false, features = ["zlib-ng"]}
-flume = "0.11.1"
 gzp = "1.0.1"
 isatty = "0.1.9"
 itertools = "0.10.5"
@@ -44,7 +43,6 @@ mimalloc = {version = "0.1.43", default-features = false}
 num_cpus = "1.16.0"
 parking_lot = "0.11.2"
 proglog = {version = "0.3.0", features = ["pretty_counts"]}
-rayon = "1.10.0"
 regex = {version = "1.11.1", default-features = false, features = ["perf", "perf-onepass", "perf-inline", "perf-literal"]}
 # for https://github.com/markschl/seq_io/pull/23
 #seq_io = "0.3.3"

--- a/src/lib/color.rs
+++ b/src/lib/color.rs
@@ -10,9 +10,9 @@ pub const COLOR_HEAD: Color = Color::Fixed(30);
 pub const COLOR_BACKGROUND: Color = Color::Fixed(240);
 
 /// Colors the text with the given color
-pub fn color(text: &[u8], colour: &Color) -> Vec<u8> {
+pub fn color(text: &[u8], color: &Color) -> Vec<u8> {
     let mut colored: Vec<u8> = Vec::with_capacity(text.len());
-    colour.paint(text).write_to(&mut colored).unwrap();
+    color.paint(text).write_to(&mut colored).unwrap();
     colored
 }
 

--- a/src/lib/matcher.rs
+++ b/src/lib/matcher.rs
@@ -2,11 +2,11 @@ use bitvec::prelude::*;
 use seq_io::fastq::RefRecord;
 use std::ops::Range;
 
-use crate::color::{color_background, color_head};
-use crate::color::{COLOR_BACKGROUND, COLOR_BASES, COLOR_QUALS};
-use crate::reverse_complement;
 use crate::DNA_BASES;
-use anyhow::{bail, Context, Result};
+use crate::color::{COLOR_BACKGROUND, COLOR_BASES, COLOR_QUALS};
+use crate::color::{color_background, color_head};
+use crate::reverse_complement;
+use anyhow::{Context, Result, bail};
 use bstr::ByteSlice;
 use regex::bytes::{Regex, RegexBuilder, RegexSet, RegexSetBuilder};
 use seq_io::fastq::{OwnedRecord, Record};
@@ -161,6 +161,8 @@ pub trait Matcher {
         }
     }
 
+    /// Adds ANSI color codes to the read's header, sequence, and quality based on where they
+    /// match the pattern(s).
     #[inline]
     fn color(&self, read: &mut OwnedRecord, match_found: bool) {
         if match_found {

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -8,26 +8,23 @@
 pub mod color;
 pub mod matcher;
 pub mod seq_io;
-use lazy_static::lazy_static;
-use std::{borrow::Borrow, path::Path};
+use std::{borrow::Borrow, path::Path, sync::LazyLock};
 
 pub const DNA_BASES: [u8; 5] = *b"ACGTN";
 pub const IUPAC_BASES: [u8; 15] = *b"AGCTYRWSKMDVHBN";
 pub const IUPAC_BASES_COMPLEMENT: [u8; 15] = *b"TCGARYWSMKHBDVN";
 
-lazy_static! {
-    pub static ref COMPLEMENT: [u8; 256] = {
-        let mut comp = [0; 256];
-        for (v, a) in comp.iter_mut().enumerate() {
-            *a = v as u8;
-        }
-        for (&a, &b) in IUPAC_BASES.iter().zip(IUPAC_BASES_COMPLEMENT.iter()) {
-            comp[a as usize] = b;
-            comp[a as usize + 32] = b + 32;  // lowercase variants
-        }
-        comp
-    };
-}
+static COMPLEMENT: LazyLock<[u8; 256]> = LazyLock::new(|| {
+    let mut comp = [0; 256];
+    for (v, a) in comp.iter_mut().enumerate() {
+        *a = v as u8;
+    }
+    for (&a, &b) in IUPAC_BASES.iter().zip(IUPAC_BASES_COMPLEMENT.iter()) {
+        comp[a as usize] = b;
+        comp[a as usize + 32] = b + 32; // lowercase variants
+    }
+    comp
+});
 
 fn complement(a: u8) -> u8 {
     COMPLEMENT[a as usize]

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -7,6 +7,7 @@
 )]
 pub mod color;
 pub mod matcher;
+pub mod seq_io;
 use lazy_static::lazy_static;
 use std::{borrow::Borrow, path::Path};
 

--- a/src/lib/seq_io.rs
+++ b/src/lib/seq_io.rs
@@ -1,0 +1,142 @@
+/// Additions to `seq_io::parallel` for interleaved paired end FASTQ files
+use anyhow::Result;
+use itertools::{self, Itertools};
+use seq_io::fastq::{self, RecordSet, RefRecord};
+use seq_io::parallel_record_impl;
+use serde::{Deserialize, Serialize};
+use std::io;
+
+parallel_record_impl!(
+    parallel_interleaved_fastq,
+    parallel_interleaved_fastq_init,
+    R,
+    InterleavedFastqReader<R>,
+    InterleavedRecordSet,
+    (fastq::RefRecord, fastq::RefRecord),
+    fastq::Error
+);
+
+pub struct InterleavedFastqReader<R: std::io::Read, P = seq_io::policy::StdPolicy> {
+    pub reader: fastq::Reader<R, P>,
+}
+
+impl<R, P> seq_io::parallel::Reader for InterleavedFastqReader<R, P>
+where
+    R: std::io::Read,
+    P: seq_io::policy::BufPolicy + Send,
+{
+    type DataSet = InterleavedRecordSet;
+    type Err = fastq::Error;
+
+    fn fill_data(
+        &mut self,
+        record: &mut Self::DataSet,
+    ) -> Option<std::result::Result<(), Self::Err>> {
+        self.reader.read_record_set_limited(&mut record.set, 65536)
+    }
+}
+
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct InterleavedRecordSet {
+    set: RecordSet,
+}
+
+impl<'a> std::iter::IntoIterator for &'a InterleavedRecordSet {
+    type Item = (RefRecord<'a>, RefRecord<'a>);
+    type IntoIter = PairedRecordSetIterator<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        let iter = self.set.into_iter().tuples();
+        // TODO: check even #
+
+        PairedRecordSetIterator {
+            iter: Box::new(iter),
+        }
+    }
+}
+
+parallel_record_impl!(
+    parallel_paired_fastq,
+    parallel_paired_fastq_init,
+    R,
+    PairedFastqReader<R>,
+    RecordSetTuple,
+    (fastq::RefRecord, fastq::RefRecord),
+    fastq::Error
+);
+
+pub struct PairedFastqReader<R: std::io::Read, P = seq_io::policy::StdPolicy> {
+    pub reader1: fastq::Reader<R, P>,
+    pub reader2: fastq::Reader<R, P>,
+}
+
+impl<R, P> seq_io::parallel::Reader for PairedFastqReader<R, P>
+where
+    R: std::io::Read,
+    P: seq_io::policy::BufPolicy + Send,
+{
+    type DataSet = RecordSetTuple;
+    type Err = fastq::Error;
+
+    fn fill_data(
+        &mut self,
+        record: &mut Self::DataSet,
+    ) -> Option<std::result::Result<(), Self::Err>> {
+        let result1 = self
+            .reader1
+            .read_record_set_limited(&mut record.first, 65536);
+        let result2 = self
+            .reader2
+            .read_record_set_limited(&mut record.second, 65536);
+
+        match (result1, result2) {
+            (None, None) => None,
+            (Some(Ok(())), Some(Ok(()))) => Some(Ok(())),
+            (_, Some(Err(e))) | (Some(Err(e)), _) => Some(Err(e)),
+            (None, _) => Some(Err(fastq::Error::UnexpectedEnd {
+                pos: fastq::ErrorPosition {
+                    line: self.reader2.position().line(),
+                    id: None,
+                },
+            })),
+            (_, None) => Some(Err(fastq::Error::UnexpectedEnd {
+                pos: fastq::ErrorPosition {
+                    line: self.reader1.position().line(),
+                    id: None,
+                },
+            })),
+        }
+        // TODO: check the same # of reads
+    }
+}
+
+pub struct PairedRecordSetIterator<'a> {
+    iter: Box<dyn Iterator<Item = (RefRecord<'a>, RefRecord<'a>)> + 'a>,
+}
+
+impl<'a> Iterator for PairedRecordSetIterator<'a> {
+    type Item = (RefRecord<'a>, RefRecord<'a>);
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}
+
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RecordSetTuple {
+    first: RecordSet,
+    second: RecordSet,
+}
+impl<'a> std::iter::IntoIterator for &'a RecordSetTuple {
+    type Item = (RefRecord<'a>, RefRecord<'a>);
+    type IntoIter = PairedRecordSetIterator<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        #[allow(clippy::useless_conversion)]
+        let iter = self.first.into_iter().zip(self.second.into_iter());
+        PairedRecordSetIterator {
+            iter: Box::new(iter),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ use fqgrep_lib::seq_io::{
 use fqgrep_lib::{is_fastq_path, is_gzip_path};
 use gzp::BUFSIZE;
 use isatty::stdout_isatty;
-use lazy_static::lazy_static;
 use proglog::{CountFormatterKind, ProgLog, ProgLogBuilder};
 use seq_io::fastq::{self, Record, RefRecord};
 use seq_io::parallel::parallel_fastq;
@@ -23,15 +22,15 @@ use std::{
     io::{BufRead, BufReader, BufWriter, Read, Write},
     path::PathBuf,
     str::FromStr,
+    sync::LazyLock,
 };
 
-lazy_static! {
-    /// Return the number of cpus as a String
-    pub static ref NUM_CPU: String = num_cpus::get().to_string();
-}
+/// The number of cpus as a String
+pub static NUM_CPU: LazyLock<String> = LazyLock::new(|| num_cpus::get().to_string());
 
 pub mod built_info {
-    use lazy_static::lazy_static;
+    use std::sync::LazyLock;
+
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
 
     /// Get a software version string including
@@ -52,10 +51,7 @@ pub mod built_info {
         format!("{}{}", prefix, suffix)
     }
 
-    lazy_static! {
-        /// Version of the software with git hash
-        pub static ref VERSION: String = get_software_version();
-    }
+    pub static VERSION: LazyLock<String> = LazyLock::new(get_software_version);
 }
 
 fn spawn_reader(file: PathBuf, decompress: bool) -> fastq::Reader<Box<dyn std::io::Read + Send>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -501,11 +501,6 @@ fn fqgrep_from_opts(opts: &Opts) -> Result<usize> {
                         progress.record();
                     }
                     *found = matcher.read_match(&record);
-                    println!(
-                        "seq: {} result: {}",
-                        String::from_utf8_lossy(record.seq()),
-                        *found,
-                    );
                 },
                 |record, found| {
                     if *found {
@@ -527,10 +522,6 @@ fn fqgrep_from_opts(opts: &Opts) -> Result<usize> {
             )
             .unwrap();
         }
-    }
-
-    if opts.paired {
-        num_matches /= 2;
     }
 
     if opts.count {
@@ -961,15 +952,7 @@ pub mod tests {
         opts.paired = paired;
         let _result = fqgrep_from_opts(&opts);
         let return_sequences = slurp_output(result_path.to_path_buf());
-
         let sequence_match = expected_seq == return_sequences;
-        for seq in return_sequences {
-            println!("return_sequence: {seq}");
-        }
-        for seq in expected_seq {
-            println!("expected_seq: {seq}");
-        }
-        println!("pattern: {pattern:?}");
         assert_eq!(sequence_match, expected_bool);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -372,7 +372,7 @@ fn fqgrep_from_opts(opts: &Opts) -> Result<usize> {
                 opts.threads as u32,
                 opts.threads,
                 |(read1, read2), found| {
-                    *found = process_interleaved_reads(read1, read2, &matcher, &progress_logger);
+                    *found = process_paired_reads(&read1, &read2, &matcher, &progress_logger);
                 },
                 |(read1, read2), found| {
                     if *found > 0 {
@@ -434,8 +434,7 @@ fn fqgrep_from_opts(opts: &Opts) -> Result<usize> {
                     opts.threads as u32,
                     opts.threads,
                     |(read1, read2), found| {
-                        *found =
-                            process_interleaved_reads(read1, read2, &matcher, &progress_logger);
+                        *found = process_paired_reads(&read1, &read2, &matcher, &progress_logger);
                     },
                     |(read1, read2), found| {
                         if *found > 0 {
@@ -534,9 +533,10 @@ fn fqgrep_from_opts(opts: &Opts) -> Result<usize> {
 }
 
 #[allow(clippy::ref_option)] // FIXME: remove me later and solve
-fn process_interleaved_reads(
-    mut read1: RefRecord,
-    mut read2: RefRecord,
+#[allow(clippy::borrowed_box)] // FIXME: remove me later and solve
+fn process_paired_reads(
+    read1: &RefRecord,
+    read2: &RefRecord,
     matcher: &Box<dyn Matcher + Sync + Send>, //&(dyn Matcher + Sync + Send),
     progress_logger: &Option<ProgLog>,
 ) -> u32 {
@@ -552,9 +552,9 @@ fn process_interleaved_reads(
         read2.id().unwrap()
     );
     // NB: only search for a match in read2 if read1 does not have a match
-    if matcher.read_match(&mut read1) {
+    if matcher.read_match(read1) {
         1
-    } else if matcher.read_match(&mut read2) {
+    } else if matcher.read_match(read2) {
         2
     } else {
         0


### PR DESCRIPTION
This uses `seq_io`'s `parallel_fastq` to speed up `fqgrep` by re-using the `RecordSet`s to avoid allocation, inspired by `grepq`.

Paired end support (two fastqs and interleaved) needs to be implemented