### PR TITLE
chore: update to seq_io 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,8 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "seq_io"
-version = "0.3.3"
-source = "git+https://github.com/nh13/seq_io.git?rev=640160566a87b4d26e610a92026600b02218303d#640160566a87b4d26e610a92026600b02218303d"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1303559e530ee83c1d7a8593a033792c2a29217544a5c48563e116e158d76ade"
 dependencies = [
  "buffer-redux",
  "crossbeam-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,7 @@ parking_lot = "0.11.2"
 proglog = {version = "0.3.0", features = ["pretty_counts"]}
 regex = {version = "1.11.1", default-features = false, features = ["perf", "perf-onepass", "perf-inline", "perf-literal"]}
 # for https://github.com/markschl/seq_io/pull/23
-#seq_io = "0.3.3"
-seq_io = { git = "https://github.com/nh13/seq_io.git", rev = "640160566a87b4d26e610a92026600b02218303d" }
+seq_io = "0.3.4"
 
 serde = {version = "1.0.218", features = ["derive"]}
 
@@ -55,5 +54,5 @@ built = {version ="0.5.2", features = ["git2"]}
 [dev-dependencies]
 fgoxide = "0.5.0"
 rstest = "0.12.0"
-seq_io = { git = "https://github.com/nh13/seq_io.git", rev = "640160566a87b4d26e610a92026600b02218303d" }
+seq_io = "0.3.4"
 tempfile = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -362,9 +362,10 @@ fn fqgrep_from_opts(opts: &Opts) -> Result<usize> {
         if files.len() == 1 {
             // Interleaved paired end FASTQ
             parallel_interleaved_fastq(
-                InterleavedFastqReader {
-                    reader: spawn_reader(files.first().unwrap().clone(), opts.decompress),
-                },
+                InterleavedFastqReader::new(spawn_reader(
+                    files.first().unwrap().clone(),
+                    opts.decompress,
+                )),
                 opts.threads as u32,
                 opts.threads,
                 |(read1, read2), found| {
@@ -426,7 +427,7 @@ fn fqgrep_from_opts(opts: &Opts) -> Result<usize> {
                     spawn_reader(file_pairs[1].clone(), opts.decompress);
 
                 parallel_paired_fastq(
-                    PairedFastqReader { reader1, reader2 },
+                    PairedFastqReader::new(reader1, reader2),
                     opts.threads as u32,
                     opts.threads,
                     |(read1, read2), found| {


### PR DESCRIPTION
Change from nh13/seq_io to markschl/seq_io now that https://github.com/markschl/seq_io/pull/23 is merged.

~We will need to update the pyproject.toml once seq_io is released before we can make another fqgrep release.~

`seq_io` 0.3.4 has now been released!