### PR TITLE
fix: repair publish workflow and remove RC version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,10 +43,10 @@ jobs:
             target: arm-unknown-linux-gnueabihf
             asset_name: fqgrep-arm-unknown-linux-gnueabihf
           - build: macos
-            os: macos-12
+            os: macos-latest
             rust: nightly
-            target: x86_64-apple-darwin
-            asset_name: fqgrep-x86_64-apple-darwin
+            target: aarch64-apple-darwin
+            asset_name: fqgrep-aarch64-apple-darwin
           - build: win-msvc
             os: windows-2022
             rust: nightly
@@ -65,16 +65,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.job.os }}-${{ matrix.job.target }}
 
@@ -82,7 +82,7 @@ jobs:
         shell: bash
         if: ${{ matrix.use-cross == true }}
         run: |
-          cargo install cross
+          cargo install cross --locked
           echo "CARGO=cross" >> $GITHUB_ENV
       
       - name: Set target environment variables
@@ -126,7 +126,7 @@ jobs:
           fi
 
       - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: fqgrep-${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "fqgrep"
-version = "1.1.2-rc.1"
+version = "1.1.2"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fqgrep"
 authors = ["Nils Homer <nils@fulcrumgenomics.com>", "Seth Stadick <seth@fulcrumgenomics.com>"]
-version = "1.1.2-rc.1"
+version = "1.1.2"
 edition = "2024"
 license = "MIT"
 description = "Search a pair of fastq files for reads that match a given ref or alt sequence"


### PR DESCRIPTION
## Summary

- **Fix cross install failure**: add `--locked` to `cargo install cross` — without it, dependency resolution pulls `home@0.5.12` which requires rustc 1.88, breaking the build
- **Fix deprecated macOS runner**: replace `macos-12` (EOL) with `macos-latest` and switch target from `x86_64-apple-darwin` to `aarch64-apple-darwin` (Apple Silicon)
- **Pin all actions by commit hash** for supply-chain security
- **Remove `-rc.1` version suffix** from Cargo.toml so release-plz manages version bumps going forward

## Context

The `v1.1.2-rc.1` tag, GitHub release, and crates.io publish from the initial release-plz run have been cleaned up:
- Tag deleted
- GitHub release deleted
- crates.io version needs to be yanked manually (`cargo yank --version 1.1.2-rc.1 fqgrep`)

## Test plan

- [ ] Yank `1.1.2-rc.1` from crates.io
- [ ] Merge and verify the release-plz workflow creates a proper release PR for `v1.1.2`
- [ ] Verify the publish workflow succeeds on the next tag push (cross install, macOS build)