### PR TITLE
feat: support zstandard compressed FASTQ input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,6 +663,7 @@ dependencies = [
  "seq_io",
  "serde",
  "tempfile",
+ "zstd",
 ]
 
 [[package]]
@@ -2609,3 +2610,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ regex = {version = "1.11.1", default-features = false, features = ["perf", "perf
 seq_io = "0.3.4"
 
 serde = {version = "1.0.218", features = ["derive"]}
+zstd = "0.13"
 
 [build-dependencies]
 built = {version ="0.5.2", features = ["git2"]}

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The fqgrep utility searches any given input FASTQ files, selecting records whose
 
 INPUT COMPRESSION
 
-By default, the input files are assumed to be uncompressed with the following exceptions: (1) If the input files are real files and end with .gz or .bgz, they are assumed to be GZIP compressed, or (2) if they end with .zst or .zstd, they are assumed to be zstandard compressed, or (3) if they end with .fastq or .fq, they are assumed to be uncompressed, or (4) if the -Z/--decompress option is specified then any unrecongized inputs (including standard input) are assumed to be GZIP compressed.
+By default, the input files are assumed to be uncompressed with the following exceptions: (1) If the input files are real files and end with .gz or .bgz, they are assumed to be GZIP compressed, or (2) if they end with .zst or .zstd, they are assumed to be zstandard compressed, or (3) if they end with .fastq or .fq, they are assumed to be uncompressed, or (4) if the -Z/--decompress option is specified then any unrecognized inputs (including standard input) are assumed to be GZIP compressed.
 
 THREADS
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The fqgrep utility searches any given input FASTQ files, selecting records whose
 
 INPUT COMPRESSION
 
-By default, the input files are assumed to be uncompressed with the following exceptions: (1) If the input files are real files and end with .gz or .bgz, they are assumed to be GZIP compressed, or (2) if they end with .fastq or .fq, they are assumed to be uncompressed, or (3) if the -Z/--decompress option is specified then any unrecongized inputs (including standard input) are assumed to be GZIP compressed.
+By default, the input files are assumed to be uncompressed with the following exceptions: (1) If the input files are real files and end with .gz or .bgz, they are assumed to be GZIP compressed, or (2) if they end with .zst or .zstd, they are assumed to be zstandard compressed, or (3) if they end with .fastq or .fq, they are assumed to be uncompressed, or (4) if the -Z/--decompress option is specified then any unrecongized inputs (including standard input) are assumed to be GZIP compressed.
 
 THREADS
 

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -154,8 +154,8 @@ where
         .collect()
 }
 
-/// Returns true if the path ends with a recognized GZIP file extension
-fn is_path_with_extension<P: AsRef<Path>>(p: &P, extensions: [&str; 2]) -> bool {
+/// Returns true if the path ends with one of the given extensions
+fn is_path_with_extension<P: AsRef<Path>>(p: &P, extensions: &[&str]) -> bool {
     if let Some(ext) = p.as_ref().extension() {
         match ext.to_str() {
             Some(x) => extensions.contains(&x),
@@ -167,15 +167,23 @@ fn is_path_with_extension<P: AsRef<Path>>(p: &P, extensions: [&str; 2]) -> bool 
 }
 
 /// The set of file extensions to treat as GZIPPED
-const GZIP_EXTENSIONS: [&str; 2] = ["gz", "bgz"];
+const GZIP_EXTENSIONS: &[&str] = &["gz", "bgz"];
 
 /// Returns true if the path ends with a recognized GZIP file extension
 pub fn is_gzip_path<P: AsRef<Path>>(p: &P) -> bool {
     is_path_with_extension(p, GZIP_EXTENSIONS)
 }
 
+/// The set of file extensions to treat as zstandard compressed
+const ZSTD_EXTENSIONS: &[&str] = &["zst", "zstd"];
+
+/// Returns true if the path ends with a recognized zstandard file extension
+pub fn is_zstd_path<P: AsRef<Path>>(p: &P) -> bool {
+    is_path_with_extension(p, ZSTD_EXTENSIONS)
+}
+
 /// The set of file extensions to treat as FASTQ
-const FASTQ_EXTENSIONS: [&str; 2] = ["fastq", "fq"];
+const FASTQ_EXTENSIONS: &[&str] = &["fastq", "fq"];
 
 /// Returns true if the path ends with a recognized FASTQ file extension
 pub fn is_fastq_path<P: AsRef<Path>>(p: &P) -> bool {
@@ -217,6 +225,22 @@ pub mod tests {
         let result = is_gzip_path(&file_path);
         assert_eq!(result, expected);
     }
+    // ############################################################################################
+    // Tests is_zstd_path()
+    // ############################################################################################
+
+    #[rstest]
+    #[case("test_fastq.fq.zst", true)] // .fq.zst is valid zstd
+    #[case("test_fastq.fq.zstd", true)] // .fq.zstd is valid zstd
+    #[case("test_fastq.fq.gz", false)] // .fq.gz is not zstd
+    #[case("test_fastq.fq", false)] // .fq is not zstd
+    fn test_is_zstd_path(#[case] file_name: &str, #[case] expected: bool) {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join(file_name);
+        let result = is_zstd_path(&file_path);
+        assert_eq!(result, expected);
+    }
+
     // ############################################################################################
     // Tests is_fastq_path()
     // ############################################################################################

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ use proglog::{CountFormatterKind, ProgLog, ProgLogBuilder};
 use seq_io::fastq::{self, Record, RefRecord};
 use seq_io::parallel::parallel_fastq;
 use std::process::ExitCode;
-use zstd::stream::read::Decoder as ZstdDecoder;
 use std::{
     fs::File,
     io::{BufRead, BufReader, BufWriter, Read, Write},
@@ -29,6 +28,7 @@ use std::{
     str::FromStr,
     sync::LazyLock,
 };
+use zstd::stream::read::Decoder as ZstdDecoder;
 
 /// The number of cpus as a String
 pub static NUM_CPU: LazyLock<String> = LazyLock::new(|| num_cpus::get().to_string());
@@ -126,7 +126,7 @@ const STYLES: styling::Styles = styling::Styles::styled()
 /// If the input files are real files and end with `.gz` or `.bgz`, they are assumed to be GZIP
 /// compressed, or (2) if they end with `.zst` or `.zstd`, they are assumed to be zstandard
 /// compressed, or (3) if they end with `.fastq` or `.fq`, they are assumed to be uncompressed, or
-/// (4) if the `-Z/--decompress` option is specified then any unrecongized inputs (including
+/// (4) if the `-Z/--decompress` option is specified then any unrecognized inputs (including
 /// standard input) are assumed to be GZIP compressed.
 ///
 /// # THREADS

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,13 +14,14 @@ use fqgrep_lib::seq_io::{
     ordered_parallel_interleaved_fastq, ordered_parallel_paired_fastq, parallel_interleaved_fastq,
     parallel_paired_fastq,
 };
-use fqgrep_lib::{is_fastq_path, is_gzip_path};
+use fqgrep_lib::{is_fastq_path, is_gzip_path, is_zstd_path};
 use gzp::BUFSIZE;
 use isatty::stdout_isatty;
 use proglog::{CountFormatterKind, ProgLog, ProgLogBuilder};
 use seq_io::fastq::{self, Record, RefRecord};
 use seq_io::parallel::parallel_fastq;
 use std::process::ExitCode;
+use zstd::stream::read::Decoder as ZstdDecoder;
 use std::{
     fs::File,
     io::{BufRead, BufReader, BufWriter, Read, Write},
@@ -74,13 +75,14 @@ fn spawn_reader(
     let buf_handle: BufReader<Box<dyn std::io::Read + Send>> =
         BufReader::with_capacity(BUFSIZE, raw_handle);
     // Maybe wrap it in a decompressor
-    let maybe_decoder_handle: Box<dyn std::io::Read + Send> = {
-        let is_gzip = is_gzip_path(&file) || (!is_fastq_path(&file) && decompress);
-        if is_gzip {
-            Box::new(MultiGzDecoder::new(buf_handle)) as Box<dyn std::io::Read + Send>
-        } else {
-            Box::new(buf_handle) as Box<dyn std::io::Read + Send>
-        }
+    let maybe_decoder_handle: Box<dyn std::io::Read + Send> = if is_zstd_path(&file) {
+        let decoder = ZstdDecoder::with_buffer(buf_handle)
+            .with_context(|| format!("Error opening zstd input: {}", file.display()))?;
+        Box::new(decoder) as Box<dyn std::io::Read + Send>
+    } else if is_gzip_path(&file) || (!is_fastq_path(&file) && decompress) {
+        Box::new(MultiGzDecoder::new(buf_handle)) as Box<dyn std::io::Read + Send>
+    } else {
+        Box::new(buf_handle) as Box<dyn std::io::Read + Send>
     };
     // Open a FASTQ reader
     Ok(fastq::Reader::with_capacity(maybe_decoder_handle, BUFSIZE))
@@ -122,8 +124,9 @@ const STYLES: styling::Styles = styling::Styles::styled()
 ///
 /// By default, the input files are assumed to be uncompressed with the following exceptions: (1)
 /// If the input files are real files and end with `.gz` or `.bgz`, they are assumed to be GZIP
-/// compressed, or (2) if they end with `.fastq` or `.fq`, they are assumed to be uncompressed, or
-/// (3) if the `-Z/--decompress` option is specified then any unrecongized inputs (including
+/// compressed, or (2) if they end with `.zst` or `.zstd`, they are assumed to be zstandard
+/// compressed, or (3) if they end with `.fastq` or `.fq`, they are assumed to be uncompressed, or
+/// (4) if the `-Z/--decompress` option is specified then any unrecongized inputs (including
 /// standard input) are assumed to be GZIP compressed.
 ///
 /// # THREADS
@@ -775,6 +778,7 @@ pub mod tests {
     use rstest::rstest;
     use seq_io::fastq::{OwnedRecord, Record};
     use tempfile::TempDir;
+    use zstd::stream::write::Encoder as ZstdEncoder;
 
     /// Returns the path(s)  of type `Vec<String>` to the fastq(s) written from the provided sequence
     ///
@@ -799,8 +803,16 @@ pub mod tests {
         for (fastq_index, fastq_sequences) in sequences_per_fastq.iter().enumerate() {
             let name = format!("sample_{fastq_index}{file_extension}");
             let fastq_path = temp_dir.path().join(name);
-            let io = Io::default();
-            let mut writer = io.new_writer(&fastq_path).unwrap();
+
+            // fgoxide's writer handles `.gz`/`.bgz` but not zstd, so wrap manually for `.zst`.
+            let mut writer: Box<dyn Write> = if is_zstd_path(&fastq_path) {
+                let file = File::create(&fastq_path).unwrap();
+                let encoder = ZstdEncoder::new(file, 0).unwrap().auto_finish();
+                Box::new(BufWriter::new(encoder))
+            } else {
+                let io = Io::default();
+                Box::new(io.new_writer(&fastq_path).unwrap())
+            };
 
             // Second loop through &str in &Vec<Vec<&str>>
             for (num, seq) in fastq_sequences.iter().enumerate() {
@@ -1105,7 +1117,9 @@ pub mod tests {
     fn slurp_fastq(path: &PathBuf) -> Vec<OwnedRecord> {
         let handle = File::open(path).unwrap();
         let buf_handle = BufReader::with_capacity(BUFSIZE, handle);
-        let maybe_decoder_handle: Box<dyn Read> = if is_gzip_path(path) {
+        let maybe_decoder_handle: Box<dyn Read> = if is_zstd_path(path) {
+            Box::new(ZstdDecoder::with_buffer(buf_handle).unwrap())
+        } else if is_gzip_path(path) {
             Box::new(MultiGzDecoder::new(buf_handle))
         } else {
             Box::new(buf_handle)
@@ -1273,7 +1287,7 @@ pub mod tests {
     }
 
     // ############################################################################################
-    // Tests that correct match count is returned from .fq, .fastq, .fq.gz, and .fq.bgz
+    // Tests that correct match count is returned from .fq, .fastq, .fq.gz, .fq.bgz, and .fq.zst
     // ############################################################################################
     // Three matches are found from all file types
     #[rstest]
@@ -1281,6 +1295,8 @@ pub mod tests {
     #[case(String::from(".fastq"), 3)]
     #[case(String::from(".fq.gz"), 3)]
     #[case(String::from(".fq.bgz"), 3)]
+    #[case(String::from(".fq.zst"), 3)]
+    #[case(String::from(".fq.zstd"), 3)]
     fn test_fastq_compression(#[case] extension: String, #[case] expected: usize) {
         let dir = TempDir::new().unwrap();
         let seqs = vec![

--- a/src/main.rs
+++ b/src/main.rs
@@ -807,7 +807,9 @@ pub mod tests {
             // fgoxide's writer handles `.gz`/`.bgz` but not zstd, so wrap manually for `.zst`.
             let mut writer: Box<dyn Write> = if is_zstd_path(&fastq_path) {
                 let file = File::create(&fastq_path).unwrap();
-                let encoder = ZstdEncoder::new(file, 0).unwrap().auto_finish();
+                let encoder = ZstdEncoder::new(file, zstd::DEFAULT_COMPRESSION_LEVEL)
+                    .unwrap()
+                    .auto_finish();
                 Box::new(BufWriter::new(encoder))
             } else {
                 let io = Io::default();


### PR DESCRIPTION
Closes #20.

Recognizes `.zst` and `.zstd` input files and decodes them via the `zstd` crate, mirroring the existing gzip dispatch. CLI help and README updated; `-Z/--decompress` semantics unchanged.

## Possible follow-ups (out of scope here, happy to do either)

- Magic-byte sniffing instead of extension dispatch (would handle misnamed inputs and supersede `-Z` for the normal case).
- zstd output. `fgoxide::Io::new_writer` only knows gzip and plain today; cleanest path is teaching fgoxide zstd first, then exposing here.
